### PR TITLE
#修复了一个潜在的panic漏洞

### DIFF
--- a/core/downloader/downloader_http.go
+++ b/core/downloader/downloader_http.go
@@ -188,11 +188,11 @@ func (this *HttpDownloader) changeCharsetEncodingAuto(contentTypeStr string, sor
 func (this *HttpDownloader) changeCharsetEncodingAutoGzipSupport(contentTypeStr string, sor io.ReadCloser) string {
 	var err error
 	gzipReader, err := gzip.NewReader(sor)
-	defer gzipReader.Close()
 	if err != nil {
 		mlog.LogInst().LogError(err.Error())
 		return ""
 	}
+	defer gzipReader.Close()
 	destReader, err := charset.NewReader(gzipReader, contentTypeStr)
 
 	if err != nil {


### PR DESCRIPTION
changeCharsetEncodingAutoGzipSupport函数的
defer gzipReader.Close() 必须在判断 err之后，否则当在err产生的时候会产生 nil.Close导致 panic